### PR TITLE
Remove unused upcoming notes feature

### DIFF
--- a/src/the_assistant/integrations/obsidian/filter_engine.py
+++ b/src/the_assistant/integrations/obsidian/filter_engine.py
@@ -177,39 +177,6 @@ class FilterEngine:
 
         return filtered_notes
 
-    def get_upcoming_notes(
-        self,
-        notes: list[ObsidianNote],
-        days_ahead: int = 30,
-        reference_date: date | None = None,
-    ) -> list[ObsidianNote]:
-        """
-        Get notes with start_date in the upcoming days.
-
-        Args:
-            notes: List of ObsidianNote objects to filter
-            days_ahead: Number of days to look ahead
-            reference_date: Reference date (defaults to today)
-
-        Returns:
-            List of notes with start_date in the upcoming period
-        """
-        if reference_date is None:
-            reference_date = date.today()
-
-        end_date = reference_date + timedelta(days=days_ahead)
-
-        upcoming_notes = []
-        for note in notes:
-            start_date = note.start_date
-
-            # Include notes that start in the upcoming period
-            if start_date and reference_date <= start_date <= end_date:
-                upcoming_notes.append(note)
-
-        # Sort by start_date
-        return sorted(upcoming_notes, key=lambda note: note.start_date or date.max)
-
     def filter_by_pending_tasks(
         self, notes: list[ObsidianNote], has_pending_tasks: bool = True
     ) -> list[ObsidianNote]:

--- a/tests/unit/integrations/obsidian/test_filter_engine.py
+++ b/tests/unit/integrations/obsidian/test_filter_engine.py
@@ -227,28 +227,6 @@ class TestFilterEngine:
         filtered = filter_engine.filter_by_properties(sample_notes, {})
         assert len(filtered) == len(sample_notes)
 
-    def test_get_upcoming_notes(self, filter_engine, sample_notes):
-        """Test getting upcoming notes."""
-        # Use a fixed reference date for testing
-        reference_date = date(2025, 2, 1)
-
-        # Get notes starting in the next 30 days from reference date
-        upcoming = filter_engine.get_upcoming_notes(sample_notes, 30, reference_date)
-
-        # Should only include Tokyo note (starts Feb 10)
-        assert len(upcoming) == 1
-        assert upcoming[0].title == "Business Trip to Tokyo"
-
-        # Test with 60 days ahead (should include Paris note too)
-        upcoming_60 = filter_engine.get_upcoming_notes(sample_notes, 60, reference_date)
-        assert len(upcoming_60) == 2
-        assert "Business Trip to Tokyo" in [note.title for note in upcoming_60]
-        assert "Trip to Paris" in [note.title for note in upcoming_60]
-
-        # Verify sorting by start_date
-        assert upcoming_60[0].title == "Business Trip to Tokyo"  # Feb 10
-        assert upcoming_60[1].title == "Trip to Paris"  # Mar 15
-
     def test_filter_by_pending_tasks(self, filter_engine, sample_notes):
         """Test filtering notes by pending task status."""
         # Filter for notes with pending tasks

--- a/tests/unit/integrations/obsidian/test_obsidian_client.py
+++ b/tests/unit/integrations/obsidian/test_obsidian_client.py
@@ -82,7 +82,6 @@ def mock_filter_engine():
         instance.filter_notes = MagicMock()
         instance.filter_by_tags = MagicMock()
         instance.filter_by_date_range = MagicMock()
-        instance.get_upcoming_notes = MagicMock()
         instance.search_by_content = MagicMock()
 
         yield instance
@@ -419,28 +418,6 @@ class TestObsidianClient:
 
         # Verify mock calls
         mock_filter_engine.filter_notes.assert_called_once_with([sample_note], filters)
-
-    async def test_get_upcoming_notes_using_filter_engine(
-        self, client, mock_filter_engine, sample_note
-    ):
-        """Test getting upcoming notes using FilterEngine directly."""
-        # Configure mocks
-        client.get_notes = AsyncMock(return_value=[sample_note])
-        mock_filter_engine.get_upcoming_notes.return_value = [sample_note]
-
-        # Call the filter engine method directly (since we removed the wrapper)
-        all_notes = await client.get_notes()
-        result = client.filter_engine.get_upcoming_notes(all_notes, days_ahead=30)
-
-        # Verify results
-        assert len(result) == 1
-        assert result[0].title == "Test Note"
-
-        # Verify mock calls
-        client.get_notes.assert_called_once()
-        mock_filter_engine.get_upcoming_notes.assert_called_once_with(
-            all_notes, days_ahead=30
-        )
 
     async def test_get_pending_tasks(self, client, sample_note):
         """Test getting pending tasks."""


### PR DESCRIPTION
## Summary
- delete `FilterEngine.get_upcoming_notes`
- remove tests exercising upcoming notes logic

## Testing
- `python -m pytest tests/unit/ -v`

------
https://chatgpt.com/codex/tasks/task_e_68812f0c84b483219258c3a5fb9755cf