### PR TITLE
Add Google auth Telegram command

### DIFF
--- a/scripts/test_oauth_flow.py
+++ b/scripts/test_oauth_flow.py
@@ -12,9 +12,8 @@ from pathlib import Path
 # Add src to path
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
-from cryptography.fernet import Fernet
-from the_assistant.integrations.google.credential_store import PostgresCredentialStore
 from the_assistant.integrations.google.client import GoogleClient
+from the_assistant.integrations.google.credential_store import PostgresCredentialStore
 
 logger = logging.getLogger(__name__)
 
@@ -22,62 +21,59 @@ logger = logging.getLogger(__name__)
 async def test_credential_store():
     """Test credential store operations."""
     print("Testing credential store...")
-    
+
     # Get configuration
     database_url = os.getenv(
-        "DATABASE_URL", 
-        "postgresql://temporal:temporal@localhost:5432/the_assistant"
+        "DATABASE_URL", "postgresql://temporal:temporal@localhost:5432/the_assistant"
     )
     encryption_key = os.getenv("DB_ENCRYPTION_KEY")
     if not encryption_key:
         raise SystemExit("DB_ENCRYPTION_KEY is required")
-    
+
     # Create store
     store = PostgresCredentialStore(database_url, encryption_key)
-    
+
     # Test user ID (from our seeded data)
     user_id = 1
-    
+
     # Test get (should be None initially)
     creds = await store.get(user_id)
     print(f"Initial credentials: {creds}")
-    
+
     print("Credential store test completed!")
 
 
 async def test_google_client():
     """Test Google client operations."""
     print("Testing Google client...")
-    
-    client = GoogleClient(
-        user_id=1
-    )
-    
+
+    client = GoogleClient(user_id=1)
+
     # Test authentication status
     is_authenticated = await client.is_authenticated()
     print(f"User authenticated: {is_authenticated}")
-    
+
     # Test auth URL generation
     try:
-        auth_url = await client.generate_auth_url("http://localhost:9000/google/oauth2callback")
+        auth_url = await client.generate_auth_url()
         print(f"Auth URL generated: {auth_url[:100]}...")
     except Exception as e:
         print(f"Failed to generate auth URL: {e}")
-    
+
     print("Google client test completed!")
 
 
 async def main():
     """Run all tests."""
     logging.basicConfig(level=logging.INFO)
-    
+
     print("Starting OAuth2 flow tests...")
-    
+
     await test_credential_store()
     await test_google_client()
-    
+
     print("All tests completed!")
 
 
 if __name__ == "__main__":
-    asyncio.run(main()) 
+    asyncio.run(main())

--- a/src/the_assistant/integrations/google/oauth_state.py
+++ b/src/the_assistant/integrations/google/oauth_state.py
@@ -1,0 +1,31 @@
+import logging
+from datetime import UTC, datetime, timedelta
+
+import jwt
+
+from ...settings import Settings
+
+logger = logging.getLogger(__name__)
+
+
+def create_state_jwt(user_id: int, settings: Settings) -> str:
+    """Create a JWT state token for OAuth2 flow."""
+    payload = {
+        "user_id": user_id,
+        "exp": datetime.now(UTC) + timedelta(minutes=10),
+        "iat": datetime.now(UTC),
+    }
+    return jwt.encode(payload, settings.jwt_secret, algorithm="HS256")
+
+
+def parse_state_jwt(state: str, settings: Settings) -> int | None:
+    """Parse and validate JWT state token."""
+    try:
+        payload = jwt.decode(state, settings.jwt_secret, algorithms=["HS256"])
+        return payload.get("user_id")
+    except jwt.ExpiredSignatureError:
+        logger.warning("State token expired")
+        return None
+    except jwt.InvalidTokenError:
+        logger.warning("Invalid state token")
+        return None

--- a/src/the_assistant/integrations/telegram/telegram_client.py
+++ b/src/the_assistant/integrations/telegram/telegram_client.py
@@ -25,6 +25,8 @@ from telegram.ext import (
 )
 
 from the_assistant.db import get_user_service
+from the_assistant.integrations.google.client import GoogleClient
+from the_assistant.integrations.google.oauth_state import create_state_jwt
 from the_assistant.settings import get_settings
 
 logger = logging.getLogger(__name__)
@@ -438,6 +440,42 @@ async def handle_settings_command(
     logger.info(f"Sent settings to user {user_id}")
 
 
+async def handle_google_auth_command(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> None:
+    """Handle the /google_auth command.
+
+    Sends the user a Google OAuth authorization link if they are not yet
+    authenticated. When the OAuth flow completes the user will receive a
+    confirmation message.
+    """
+
+    chat_user = update.effective_user
+    user_service = get_user_service()
+
+    user = await user_service.get_user_by_telegram_chat_id(chat_user.id)
+    if not user:
+        raise ValueError("User not registered")
+
+    client = GoogleClient(user.id)
+    if await client.is_authenticated():
+        await update.message.reply_text(
+            "✅ You are already authenticated with Google.",
+        )  # type: ignore
+        return
+
+    settings = get_settings()
+    state = create_state_jwt(user.id, settings)
+    auth_url = await client.generate_auth_url(state)
+
+    message = (
+        f"Please [authorize access]({auth_url}) to your Google account. "
+        "You'll receive a confirmation once completed."
+    )
+    await update.message.reply_text(message, parse_mode=ParseMode.MARKDOWN)  # type: ignore
+    logger.info(f"Sent Google auth link to user {chat_user.id}")
+
+
 async def create_telegram_client() -> TelegramClient:
     """Create a TelegramClient instance using environment variables.
 
@@ -462,5 +500,6 @@ async def create_telegram_client() -> TelegramClient:
     await client.register_command_handler("help", handle_help_command)
     await client.register_command_handler("briefing", handle_briefing_command)
     await client.register_command_handler("settings", handle_settings_command)
+    await client.register_command_handler("google_auth", handle_google_auth_command)
 
     return client

--- a/tests/unit/integrations/google/test_client.py
+++ b/tests/unit/integrations/google/test_client.py
@@ -160,9 +160,7 @@ class TestGoogleClient:
 
         client = GoogleClient(user_id=1)
 
-        auth_url = await client.generate_auth_url(
-            "http://localhost:8080/callback", "test_state"
-        )
+        auth_url = await client.generate_auth_url("test_state")
 
         assert auth_url == "https://auth.url"
         mock_flow.authorization_url.assert_called_once_with(
@@ -189,7 +187,7 @@ class TestGoogleClient:
         # We manually set it here for isolated testing
         client._oauth_flow = mock_flow
 
-        await client.exchange_code("auth_code", "http://localhost:8080/callback")
+        await client.exchange_code("auth_code")
 
         mock_flow.fetch_token.assert_called_once_with(code="auth_code")
         self.mock_store_instance.save.assert_called_once_with(1, mock_credentials)

--- a/tests/unit/integrations/google/test_oauth_router.py
+++ b/tests/unit/integrations/google/test_oauth_router.py
@@ -1,6 +1,9 @@
 import importlib
 import os
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
 
 
 def test_missing_jwt_secret_no_error():
@@ -9,3 +12,49 @@ def test_missing_jwt_secret_no_error():
         import the_assistant.integrations.google.oauth_router as oauth_router
 
         importlib.reload(oauth_router)
+
+
+@pytest.mark.asyncio
+async def test_oauth_callback_sends_notification():
+    """OAuth callback notifies the user via Telegram."""
+
+    import the_assistant.integrations.google.oauth_router as oauth_router
+
+    user = SimpleNamespace(id=1, telegram_chat_id=456)
+    service = AsyncMock()
+    service.get_user_by_id = AsyncMock(return_value=user)
+
+    google_client = AsyncMock()
+    telegram_client = AsyncMock()
+
+    settings = SimpleNamespace(
+        google_oauth_redirect_uri="http://redir",
+        jwt_secret="secret",
+    )
+    state = oauth_router.create_state_jwt(user.id, settings)
+
+    with (
+        patch(
+            "the_assistant.integrations.google.oauth_router.get_user_service",
+            return_value=service,
+        ),
+        patch(
+            "the_assistant.integrations.google.oauth_router.GoogleClient",
+            return_value=google_client,
+        ),
+        patch(
+            "the_assistant.integrations.google.oauth_router.TelegramClient",
+            return_value=telegram_client,
+        ),
+    ):
+        await oauth_router.google_oauth_callback(
+            code="code",
+            state=state,
+            error=None,
+            settings=settings,
+        )
+
+    google_client.exchange_code.assert_awaited_once_with("code")
+    telegram_client.send_message.assert_awaited_once_with(
+        chat_id=456, text="✅ Google authentication successful!"
+    )


### PR DESCRIPTION
## Summary
- support `/google_auth` Telegram command that sends OAuth link
- notify Telegram user when Google auth flow completes
- register google_auth command by default
- test google OAuth callback notification
- test google_auth command handler

## Testing
- `make fix`
- `make typecheck`
- `make test-unit`


------
https://chatgpt.com/codex/tasks/task_e_688245af0e848321a9ff5abd90434cc8