### PR TITLE
Improve briefing workflow for richer context

### DIFF
--- a/src/the_assistant/activities/__init__.py
+++ b/src/the_assistant/activities/__init__.py
@@ -5,12 +5,15 @@ from .google_activities import (
     get_calendar_events,
     get_emails,
     get_events_by_date,
+    get_important_emails,
     get_today_events,
     get_upcoming_events,
 )
 from .messages_activities import (
+    build_briefing_prompt,
     build_briefing_summary,
     build_daily_briefing,
+    get_user_settings,
 )
 from .obsidian_activities import (
     scan_vault_notes,
@@ -28,6 +31,7 @@ __all__ = [
     "get_today_events",
     "get_upcoming_events",
     "get_emails",
+    "get_important_emails",
     # Obsidian activities
     "scan_vault_notes",
     # Weather activities
@@ -35,6 +39,8 @@ __all__ = [
     # Telegram activities
     "build_daily_briefing",
     "build_briefing_summary",
+    "build_briefing_prompt",
+    "get_user_settings",
     "send_formatted_message",
     "send_message",
 ]

--- a/src/the_assistant/models/google.py
+++ b/src/the_assistant/models/google.py
@@ -79,6 +79,7 @@ class GmailMessage(BaseAssistantModel):
     sender: str = Field(default="", description="Sender email")
     to: str = Field(default="", description="Recipient email")
     date: datetime | None = Field(default=None, description="Message date")
+    body: str = Field(default="", description="Plain text body")
     raw_data: dict[str, Any] = Field(
         default_factory=dict, description="Original API response data"
     )

--- a/src/the_assistant/worker.py
+++ b/src/the_assistant/worker.py
@@ -17,12 +17,15 @@ from the_assistant.activities.google_activities import (
     get_calendar_events,
     get_emails,
     get_events_by_date,
+    get_important_emails,
     get_today_events,
     get_upcoming_events,
 )
 from the_assistant.activities.messages_activities import (
+    build_briefing_prompt,
     build_briefing_summary,
     build_daily_briefing,
+    get_user_settings,
 )
 from the_assistant.activities.obsidian_activities import (
     scan_vault_notes,
@@ -67,6 +70,7 @@ async def run_worker() -> None:
                 get_events_by_date,
                 get_today_events,
                 get_emails,
+                get_important_emails,
                 # Obsidian activities
                 scan_vault_notes,
                 # Weather activities
@@ -74,6 +78,8 @@ async def run_worker() -> None:
                 # Messages activities
                 build_daily_briefing,
                 build_briefing_summary,
+                build_briefing_prompt,
+                get_user_settings,
                 # Telegram activities
                 send_message,
             ],

--- a/tests/unit/test_activities.py
+++ b/tests/unit/test_activities.py
@@ -312,6 +312,7 @@ class TestEmailActivities:
                 snippet="hi",
                 subject="Hello",
                 sender="sender@example.com",
+                body="Body",
             )
         ]
 
@@ -377,6 +378,7 @@ class TestMessagesActivities:
             snippet="snippet",
             subject="Subject",
             sender="sender@example.com",
+            body="Body",
         )
 
         text = await build_daily_briefing(


### PR DESCRIPTION
## Summary
- support email body in `GmailMessage`
- allow reading important Gmail messages and extract message bodies
- expose new activities for fetching important emails, user settings and building briefing prompts
- include upcoming events, email summaries and settings in the daily briefing workflow
- adjust LLM prompt to highlight important info
- update tests for new features

## Testing
- `make format`
- `make lint-src`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68832e2e1c0c8321977484fe3f285199