### PR TITLE
Mount local code in dev containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,10 @@ docker-compose up -d
 
 # Check logs
 docker-compose logs -f app
+
+# After modifying source code, simply restart the affected containers
+# without rebuilding the images:
+docker-compose restart app worker telegram-bot
 ```
 
 **Production mode**:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,7 @@ services:
     volumes:
       - ./obsidian_vault:/vault # Mount local vault
       - ./secrets:/secrets # Mount folder for file-based secrets
+      - ./src:/app/src # Mount local source code
     depends_on:
       - temporal
       - postgresql
@@ -66,6 +67,7 @@ services:
     volumes:
       - ./obsidian_vault:/vault # Mount local vault
       - ./secrets:/secrets # Mount folder for file-based secrets
+      - ./src:/app/src # Mount local source code
     depends_on:
       - temporal
       - postgresql
@@ -80,6 +82,7 @@ services:
     volumes:
       - ./obsidian_vault:/vault # Mount local vault
       - ./secrets:/secrets # Mount folder for file-based secrets
+      - ./src:/app/src # Mount local source code
     depends_on:
       - temporal
       - postgresql


### PR DESCRIPTION
## Summary
- mount `./src` in docker-compose services so rebuilding isn't needed after code updates
- document how to restart containers after editing source code

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688366c616488321864e5226a14b9182