### PR TITLE
Allow specifying account with /google_auth

### DIFF
--- a/src/the_assistant/integrations/telegram/telegram_client.py
+++ b/src/the_assistant/integrations/telegram/telegram_client.py
@@ -647,7 +647,10 @@ async def handle_google_auth_command(
     if not user:
         raise ValueError("User not registered")
 
-    client = GoogleClient(user.id)
+    args = getattr(context, "args", [])
+    account = args[0] if args else None
+
+    client = GoogleClient(user.id, account=account)
     if await client.is_authenticated():
         await update.message.reply_text(
             "✅ You are already authenticated with Google.",
@@ -655,7 +658,7 @@ async def handle_google_auth_command(
         return
 
     settings = get_settings()
-    state = create_state_jwt(user.id, settings)
+    state = create_state_jwt(user.id, settings, account=account)
     auth_url = await client.generate_auth_url(state)
 
     message = (


### PR DESCRIPTION
## Summary
- enable optional `account` argument for `/google_auth` Telegram command
- verify account handling in unit tests

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68837170ff20832193dd42faf59cf908