### PR TITLE
Add user-bound agent tools

### DIFF
--- a/src/the_assistant/integrations/__init__.py
+++ b/src/the_assistant/integrations/__init__.py
@@ -1,1 +1,5 @@
-# Integration modules
+"""Integration package for external services and agent tools."""
+
+from .agent_tools import get_default_tools
+
+__all__ = ["get_default_tools"]

--- a/src/the_assistant/integrations/agent_tools.py
+++ b/src/the_assistant/integrations/agent_tools.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from langchain_core.tools import tool
 
 from .google.client import GoogleClient

--- a/src/the_assistant/integrations/agent_tools.py
+++ b/src/the_assistant/integrations/agent_tools.py
@@ -22,7 +22,7 @@ async def _get_email(user_id: int, email_id: str, account: str | None = None) ->
     return email.model_dump()
 
 
-def get_default_tools(user_id: int):
+def get_default_tools(user_id: int) -> list[BaseTool]:
     """Return default agent tools bound to the given user."""
 
     @tool

--- a/src/the_assistant/integrations/agent_tools.py
+++ b/src/the_assistant/integrations/agent_tools.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from langchain_core.tools import tool
+
+from .google.client import GoogleClient
+from .telegram.telegram_client import TelegramClient
+
+
+async def _send_message(user_id: int, text: str) -> str:
+    client = TelegramClient(user_id=user_id)
+    await client.send_message(text=text)
+    return "Message sent"
+
+
+async def _get_event(user_id: int, event_id: str, calendar_id: str = "primary") -> dict:
+    client = GoogleClient(user_id=user_id)
+    event = await client.get_event(event_id=event_id, calendar_id=calendar_id)
+    return event.model_dump()
+
+
+async def _get_email(user_id: int, email_id: str, account: str | None = None) -> dict:
+    client = GoogleClient(user_id=user_id, account=account)
+    email = await client.get_email(email_id)
+    return email.model_dump()
+
+
+def get_default_tools(user_id: int):
+    """Return default agent tools bound to the given user."""
+
+    @tool
+    async def send_message(text: str) -> str:
+        """Send a Telegram message to the current user."""
+        return await _send_message(user_id, text)
+
+    @tool
+    async def get_event(event_id: str, calendar_id: str = "primary") -> dict:
+        """Get a Google Calendar event by ID."""
+        return await _get_event(user_id, event_id, calendar_id)
+
+    @tool
+    async def get_email(email_id: str, account: str | None = None) -> dict:
+        """Get a full Gmail message by ID."""
+        return await _get_email(user_id, email_id, account)
+
+    return [send_message, get_event, get_email]

--- a/src/the_assistant/integrations/agent_tools.py
+++ b/src/the_assistant/integrations/agent_tools.py
@@ -1,4 +1,4 @@
-from langchain_core.tools import tool
+from langchain_core.tools import BaseTool, tool
 
 from .google.client import GoogleClient
 from .telegram.telegram_client import TelegramClient

--- a/src/the_assistant/integrations/google/client.py
+++ b/src/the_assistant/integrations/google/client.py
@@ -217,8 +217,6 @@ class GoogleClient:
         if self._calendar_service is None:
             if not self._credentials:
                 self._credentials = await self.get_credentials()
-                if not self._credentials:
-                    raise GoogleAuthError("No valid credentials available")
 
             try:
                 self._calendar_service = build(
@@ -617,8 +615,8 @@ class GoogleClient:
 
         try:
             service = await self._get_calendar_service()
-            raw_event = (
-                service.events().get(calendarId=calendar_id, eventId=event_id).execute()
+            raw_event = await asyncio.to_thread(
+                service.events().get(calendarId=calendar_id, eventId=event_id).execute
             )
             return self._parse_calendar_event(raw_event, calendar_id)
         except HttpError as e:
@@ -640,11 +638,11 @@ class GoogleClient:
 
         try:
             service = await self._get_gmail_service()
-            msg = (
+            msg = await asyncio.to_thread(
                 service.users()
                 .messages()
                 .get(userId="me", id=email_id, format="full")
-                .execute()
+                .execute
             )
             return self._parse_gmail_message(msg, include_body=True)
         except HttpError as e:

--- a/src/the_assistant/integrations/google/client.py
+++ b/src/the_assistant/integrations/google/client.py
@@ -388,6 +388,20 @@ class GoogleClient:
             }
             attendees.append(attendee)
 
+        # Extract recurrence information
+        recurrence_rules = raw_event.get("recurrence", [])
+        is_recurring = bool(recurrence_rules)
+        recurring_event_id = raw_event.get("recurringEventId")
+
+        # Parse creation and update times
+        created_time = None
+        if "created" in raw_event:
+            created_time = self._parse_datetime_string(raw_event["created"])
+
+        updated_time = None
+        if "updated" in raw_event:
+            updated_time = self._parse_datetime_string(raw_event["updated"])
+
         return CalendarEvent(
             id=event_id,
             summary=summary,
@@ -398,6 +412,11 @@ class GoogleClient:
             calendar_id=calendar_id,
             attendees=attendees,
             is_all_day=is_all_day,
+            is_recurring=is_recurring,
+            recurrence_rules=recurrence_rules,
+            recurring_event_id=recurring_event_id,
+            created_time=created_time,
+            updated_time=updated_time,
             raw_data=raw_event,
             account=self.account,
         )

--- a/tests/unit/integrations/agent/test_agent_tools.py
+++ b/tests/unit/integrations/agent/test_agent_tools.py
@@ -1,0 +1,93 @@
+from datetime import UTC, datetime
+
+import pytest
+
+from the_assistant.integrations.agent_tools import get_default_tools
+from the_assistant.models.google import CalendarEvent, GmailMessage
+
+
+@pytest.mark.asyncio
+async def test_send_message_tool(monkeypatch):
+    called = False
+
+    class DummyClient:
+        def __init__(self, user_id=None):
+            self.user_id = user_id
+
+        async def send_message(self, text: str, parse_mode: str = "Markdown"):
+            nonlocal called
+            called = True
+            assert text == "hi"
+
+    monkeypatch.setattr(
+        "the_assistant.integrations.agent_tools.TelegramClient",
+        DummyClient,
+    )
+
+    tools = get_default_tools(1)
+    send_tool = next(t for t in tools if t.name == "send_message")
+    await send_tool.arun("hi")
+    assert called
+
+
+@pytest.mark.asyncio
+async def test_get_event_tool(monkeypatch):
+    dt = datetime.now(UTC)
+    event = CalendarEvent(
+        id="e1",
+        summary="s",
+        description="",
+        start_time=dt,
+        end_time=dt,
+        location="",
+    )
+
+    class DummyClient:
+        def __init__(self, user_id=None, account=None):
+            pass
+
+        async def get_event(self, event_id: str, calendar_id: str = "primary"):
+            assert event_id == "e1"
+            return event
+
+    monkeypatch.setattr(
+        "the_assistant.integrations.agent_tools.GoogleClient",
+        DummyClient,
+    )
+
+    tools = get_default_tools(1)
+    tool_obj = next(t for t in tools if t.name == "get_event")
+    result = await tool_obj.arun("e1")
+    assert result["id"] == "e1"
+
+
+@pytest.mark.asyncio
+async def test_get_email_tool(monkeypatch):
+    email = GmailMessage(
+        id="m1",
+        thread_id="t",
+        snippet="",
+        subject="",
+        sender="",
+        to="",
+        date=None,
+        body="",
+    )
+
+    class DummyClient:
+        def __init__(self, user_id=None, account=None):
+            pass
+
+        async def get_email(self, email_id: str):
+            assert email_id == "m1"
+            return email
+
+    monkeypatch.setattr(
+        "the_assistant.integrations.agent_tools.GoogleClient",
+        DummyClient,
+    )
+
+    tools = get_default_tools(1)
+    tool_obj = next(t for t in tools if t.name == "get_email")
+    result = await tool_obj.arun("m1")
+    assert result["id"] == "m1"

--- a/tests/unit/integrations/google/test_client.py
+++ b/tests/unit/integrations/google/test_client.py
@@ -579,7 +579,9 @@ class TestGoogleClient:
             email = await client.get_email("m1")
 
             assert email.id == "m1"
-            mock_messages.get.assert_called_once_with(userId="me", id="m1", format="full")
+            mock_messages.get.assert_called_once_with(
+                userId="me", id="m1", format="full"
+            )
 
 
 def test_extract_message_body_html_conversion():

--- a/tests/unit/integrations/google/test_client.py
+++ b/tests/unit/integrations/google/test_client.py
@@ -579,7 +579,7 @@ class TestGoogleClient:
             email = await client.get_email("m1")
 
             assert email.id == "m1"
-            mock_messages.get.assert_called_once()
+            mock_messages.get.assert_called_once_with(userId="me", id="m1", format="full")
 
 
 def test_extract_message_body_html_conversion():

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -44,6 +44,96 @@ def test_calendar_event_properties():
     assert event.is_today is True  # Since start_time is today
 
 
+def test_calendar_event_recurrence():
+    """Test CalendarEvent recurrence properties."""
+    future_time = datetime.now(UTC) + timedelta(minutes=30)
+
+    # Test non-recurring event
+    non_recurring = CalendarEvent(
+        id="event1",
+        summary="One-time Meeting",
+        start_time=future_time,
+        end_time=future_time + timedelta(hours=1),
+    )
+    assert non_recurring.is_recurring is False
+    assert non_recurring.recurrence_description == ""
+    assert non_recurring.recurring_event_id is None
+
+    # Test weekly recurring event
+    weekly_recurring = CalendarEvent(
+        id="event2",
+        summary="Weekly Standup",
+        start_time=future_time,
+        end_time=future_time + timedelta(hours=1),
+        is_recurring=True,
+        recurrence_rules=["RRULE:FREQ=WEEKLY;INTERVAL=1"],
+        recurring_event_id="recurring123",
+    )
+    assert weekly_recurring.is_recurring is True
+    assert weekly_recurring.recurrence_description == "weekly"
+    assert weekly_recurring.recurring_event_id == "recurring123"
+
+    # Test daily recurring event
+    daily_recurring = CalendarEvent(
+        id="event3",
+        summary="Daily Standup",
+        start_time=future_time,
+        end_time=future_time + timedelta(hours=1),
+        is_recurring=True,
+        recurrence_rules=["RRULE:FREQ=DAILY"],
+    )
+    assert daily_recurring.is_recurring is True
+    assert daily_recurring.recurrence_description == "daily"
+
+    # Test bi-weekly recurring event
+    biweekly_recurring = CalendarEvent(
+        id="event4",
+        summary="Bi-weekly Review",
+        start_time=future_time,
+        end_time=future_time + timedelta(hours=1),
+        is_recurring=True,
+        recurrence_rules=["RRULE:FREQ=WEEKLY;INTERVAL=2"],
+    )
+    assert biweekly_recurring.is_recurring is True
+    assert biweekly_recurring.recurrence_description == "every 2 weekly"
+
+    # Test monthly recurring event
+    monthly_recurring = CalendarEvent(
+        id="event5",
+        summary="Monthly Review",
+        start_time=future_time,
+        end_time=future_time + timedelta(hours=1),
+        is_recurring=True,
+        recurrence_rules=["RRULE:FREQ=MONTHLY;INTERVAL=1"],
+    )
+    assert monthly_recurring.is_recurring is True
+    assert monthly_recurring.recurrence_description == "monthly"
+
+    # Test yearly recurring event
+    yearly_recurring = CalendarEvent(
+        id="event6",
+        summary="Annual Review",
+        start_time=future_time,
+        end_time=future_time + timedelta(hours=1),
+        is_recurring=True,
+        recurrence_rules=["RRULE:FREQ=YEARLY"],
+    )
+    assert yearly_recurring.is_recurring is True
+    assert yearly_recurring.recurrence_description == "yearly"
+
+    # Test invalid/unknown recurrence rule
+    unknown_recurring = CalendarEvent(
+        id="event7",
+        summary="Unknown Recurrence",
+        start_time=future_time,
+        end_time=future_time + timedelta(hours=1),
+        is_recurring=True,
+        recurrence_rules=["RRULE:FREQ=UNKNOWN"],
+    )
+    assert unknown_recurring.is_recurring is True
+    assert unknown_recurring.recurrence_description == "unknown"
+
+
 def test_task_item_properties():
     """Test TaskItem model properties."""
     # Create task items with different indentation levels


### PR DESCRIPTION
## Summary
- add new agent tools for sending messages and retrieving email or calendar event
- expose tools via integration package
- support fetching single event or email in Google client
- test new Google client methods and agent tools

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883a677c3748321b2feb9f74dac8c0a