### PR TITLE
Streamline email retrieval

### DIFF
--- a/src/the_assistant/activities/__init__.py
+++ b/src/the_assistant/activities/__init__.py
@@ -5,7 +5,6 @@ from .google_activities import (
     get_calendar_events,
     get_emails,
     get_events_by_date,
-    get_important_emails,
     get_today_events,
     get_upcoming_events,
 )
@@ -31,7 +30,6 @@ __all__ = [
     "get_today_events",
     "get_upcoming_events",
     "get_emails",
-    "get_important_emails",
     # Obsidian activities
     "scan_vault_notes",
     # Weather activities

--- a/src/the_assistant/integrations/google/client.py
+++ b/src/the_assistant/integrations/google/client.py
@@ -739,6 +739,7 @@ class GoogleClient:
                 msg_date = self._parse_datetime_string(date_str)
             except Exception:  # pragma: no cover - fallback
                 msg_date = None
+        is_unread = "UNREAD" in raw_message.get("labelIds", [])
 
         return GmailMessage(
             id=raw_message.get("id", ""),
@@ -751,6 +752,7 @@ class GoogleClient:
             body=self._extract_message_body(raw_message.get("payload", {}))
             if include_body
             else "",
+            unread=is_unread,
             raw_data=raw_message if include_raw else None,
             account=self.account,
         )

--- a/src/the_assistant/models/google.py
+++ b/src/the_assistant/models/google.py
@@ -44,8 +44,8 @@ class CalendarEvent(BaseAssistantModel):
     recurring_event_id: str | None = Field(
         default=None, description="ID of the recurring event series (if applicable)"
     )
-    raw_data: dict[str, Any] = Field(
-        default_factory=dict, description="Original API response data"
+    raw_data: dict[str, Any] | None = Field(
+        default=None, description="Original API response data"
     )
     account: str | None = Field(default=None, description="Google account identifier")
 
@@ -128,8 +128,8 @@ class GmailMessage(BaseAssistantModel):
     to: str = Field(default="", description="Recipient email")
     date: datetime | None = Field(default=None, description="Message date")
     body: str = Field(default="", description="Plain text body")
-    raw_data: dict[str, Any] = Field(
-        default_factory=dict, description="Original API response data"
+    raw_data: dict[str, Any] | None = Field(
+        default=None, description="Original API response data"
     )
     account: str | None = Field(default=None, description="Google account identifier")
 
@@ -137,6 +137,8 @@ class GmailMessage(BaseAssistantModel):
     @property
     def is_unread(self) -> bool:
         """Check if the message is unread."""
+        if not self.raw_data:
+            return False
         return "UNREAD" in self.raw_data.get("labelIds", [])
 
     @computed_field

--- a/src/the_assistant/models/google.py
+++ b/src/the_assistant/models/google.py
@@ -128,6 +128,7 @@ class GmailMessage(BaseAssistantModel):
     to: str = Field(default="", description="Recipient email")
     date: datetime | None = Field(default=None, description="Message date")
     body: str = Field(default="", description="Plain text body")
+    unread: bool = Field(default=False, description="Whether the message is unread")
     raw_data: dict[str, Any] | None = Field(
         default=None, description="Original API response data"
     )
@@ -155,10 +156,8 @@ class GmailMessage(BaseAssistantModel):
     @computed_field
     @property
     def is_unread(self) -> bool:
-        """Check if the message is unread."""
-        if not self.raw_data:
-            return False
-        return "UNREAD" in self.raw_data.get("labelIds", [])
+        """Return the unread status."""
+        return self.unread
 
     @computed_field
     @property

--- a/src/the_assistant/models/google.py
+++ b/src/the_assistant/models/google.py
@@ -135,6 +135,25 @@ class GmailMessage(BaseAssistantModel):
 
     @computed_field
     @property
+    def participants(self) -> list[str]:
+        """Return all message participants from sender, to, and cc fields."""
+        parts: list[str] = []
+        if self.sender:
+            parts.extend([p.strip() for p in self.sender.split(",") if p.strip()])
+        if self.to:
+            parts.extend([p.strip() for p in self.to.split(",") if p.strip()])
+        if self.raw_data:
+            headers = {
+                h["name"].lower(): h["value"]
+                for h in self.raw_data.get("payload", {}).get("headers", [])
+            }
+            cc = headers.get("cc")
+            if cc:
+                parts.extend([p.strip() for p in cc.split(",") if p.strip()])
+        return list(dict.fromkeys(parts))
+
+    @computed_field
+    @property
     def is_unread(self) -> bool:
         """Check if the message is unread."""
         if not self.raw_data:

--- a/src/the_assistant/worker.py
+++ b/src/the_assistant/worker.py
@@ -17,8 +17,6 @@ from the_assistant.activities.google_activities import (
     get_calendar_events,
     get_emails,
     get_events_by_date,
-    get_important_emails,
-    get_important_emails_accounts,
     get_today_events,
     get_upcoming_events,
     get_upcoming_events_accounts,
@@ -72,9 +70,7 @@ async def run_worker() -> None:
                 get_events_by_date,
                 get_today_events,
                 get_emails,
-                get_important_emails,
                 get_upcoming_events_accounts,
-                get_important_emails_accounts,
                 # Obsidian activities
                 scan_vault_notes,
                 # Weather activities

--- a/tests/unit/test_activities.py
+++ b/tests/unit/test_activities.py
@@ -330,9 +330,11 @@ class TestEmailActivities:
         assert result == sample_emails
         mock_google_client.is_authenticated.assert_called_once()
         mock_google_client.get_emails.assert_called_once_with(
+            query=None,
             unread_only=True,
             sender=None,
             max_results=5,
+            include_body=True,
             ignored_senders=None,
         )
 

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -26,7 +26,10 @@ from the_assistant.models.obsidian import (
 def test_calendar_event_properties():
     """Test CalendarEvent model properties."""
     # Create a calendar event in the future to ensure is_upcoming is True
-    future_time = datetime.now(UTC) + timedelta(minutes=30)
+    now = datetime.now(UTC)
+    future_time = now + timedelta(minutes=30)
+    if future_time.date() != now.date():
+        future_time = now + timedelta(seconds=1)
     event = CalendarEvent(
         id="event123",
         summary="Team Meeting",
@@ -46,7 +49,10 @@ def test_calendar_event_properties():
 
 def test_calendar_event_recurrence():
     """Test CalendarEvent recurrence properties."""
-    future_time = datetime.now(UTC) + timedelta(minutes=30)
+    now = datetime.now(UTC)
+    future_time = now + timedelta(minutes=30)
+    if future_time.date() != now.date():
+        future_time = now + timedelta(seconds=1)
 
     # Test non-recurring event
     non_recurring = CalendarEvent(


### PR DESCRIPTION
## Summary
- simplify GmailMessage to not store raw data by default
- remove special important-email logic in Google client and activities
- fetch and sort emails using new parameters
- adjust briefing prompt construction
- update workflow to gather emails via `get_emails`
- update tests

## Testing
- `ruff check src` and `ruff check tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885530aa9d48321b274b9ff56b1431f