### PR TITLE
Unify Google credential storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,13 +150,12 @@ application will exit if it is missing.
 
 The application uses a PostgreSQL database with SQLAlchemy models and Alembic migrations for schema management:
 
-1. **Users Table**: Stores user identity and integration information
+1. **Users Table**: Stores core user identity information
    - `id`: Primary key
    - `auth_provider`: Authentication provider (e.g., "telegram", "google")
    - `external_id`: External identifier from the auth provider
    - `username`: Optional username
    - `first_name`, `last_name`: User's name
-   - `google_credentials_enc`: Encrypted Google credentials (if applicable)
    - Timestamps for registration, creation, and updates
 
 2. **User Settings Table**: Stores user preferences in a key-value structure
@@ -164,6 +163,14 @@ The application uses a PostgreSQL database with SQLAlchemy models and Alembic mi
    - `user_id`: Foreign key to users table
    - `key`: Setting name
    - `value_json`: Setting value stored as JSON text
+   - Timestamps for creation and updates
+
+3. **Third Party Accounts Table**: Stores credentials for external services
+   - `id`: Primary key
+   - `user_id`: Foreign key to users table
+   - `provider`: Name of the external provider (e.g., `"google"`)
+   - `account`: Account identifier (defaults to `"default"` for Google)
+   - `credentials_enc`: Encrypted credentials data
    - Timestamps for creation and updates
 
 The database schema is managed using Alembic migrations. Use `make init-db` to initialize the database or `make migrate` to apply new migrations.

--- a/src/the_assistant/activities/__init__.py
+++ b/src/the_assistant/activities/__init__.py
@@ -21,6 +21,9 @@ from .telegram_activities import (
     send_formatted_message,
     send_message,
 )
+from .user_activities import (
+    get_user_accounts,
+)
 from .weather_activities import get_weather_forecast
 
 __all__ = [
@@ -32,6 +35,8 @@ __all__ = [
     "get_emails",
     # Obsidian activities
     "scan_vault_notes",
+    # User activities
+    "get_user_accounts",
     # Weather activities
     "get_weather_forecast",
     # Telegram activities

--- a/src/the_assistant/activities/user_activities.py
+++ b/src/the_assistant/activities/user_activities.py
@@ -1,0 +1,22 @@
+"""User-related activities for Temporal workflows."""
+
+from dataclasses import dataclass
+
+from temporalio import activity
+
+from the_assistant.db import get_user_service
+
+
+@dataclass
+class GetUserAccountsInput:
+    """Input for getting user accounts."""
+
+    user_id: int
+    provider: str
+
+
+@activity.defn
+async def get_user_accounts(input_data: GetUserAccountsInput) -> list[str]:
+    """Get all account names for a user and provider."""
+    user_service = get_user_service()
+    return await user_service.get_user_accounts(input_data.user_id, input_data.provider)

--- a/src/the_assistant/db/service.py
+++ b/src/the_assistant/db/service.py
@@ -188,3 +188,15 @@ class UserService:
             )
             await session.execute(stmt)
             await session.commit()
+
+    async def get_user_accounts(self, user_id: int, provider: str) -> list[str]:
+        """Return all account names for a user and provider."""
+        async with self._session_maker() as session:
+            stmt = select(ThirdPartyAccount.account).where(
+                ThirdPartyAccount.user_id == user_id,
+                ThirdPartyAccount.provider == provider,
+                ThirdPartyAccount.credentials_enc.is_not(None),
+            )
+            result = await session.execute(stmt)
+            accounts = result.scalars().all()
+            return [account for account in accounts if account is not None]

--- a/src/the_assistant/db/service.py
+++ b/src/the_assistant/db/service.py
@@ -97,39 +97,20 @@ class UserService:
         credentials_enc: str | None,
         account: str | None = None,
     ) -> None:
-        """Store encrypted Google credentials for a user.
+        """Store encrypted Google credentials for a user."""
 
-        When ``account`` is provided the credentials are stored in the
-        ``third_party_accounts`` table with provider ``"google"``. The original
-        ``users.google_credentials_enc`` column is still used when ``account`` is
-        ``None`` for backwards compatibility.
-        """
-        if account:
-            await self._set_third_party_credentials(
-                user_id, "google", credentials_enc, account
-            )
-            return
-
-        async with self._session_maker() as session:
-            user = await session.get(User, user_id)
-            if user is None:
-                return
-            user.google_credentials_enc = credentials_enc
-            user.google_creds_updated_at = (
-                datetime.now(UTC) if credentials_enc else None
-            )
-            await session.commit()
+        account_name = account or "default"
+        await self._set_third_party_credentials(
+            user_id, "google", credentials_enc, account_name
+        )
 
     async def get_google_credentials(
         self, user_id: int, account: str | None = None
     ) -> str | None:
         """Return encrypted Google credentials for a user."""
-        if account:
-            return await self._get_third_party_credentials(user_id, "google", account)
 
-        async with self._session_maker() as session:
-            user = await session.get(User, user_id)
-            return user.google_credentials_enc if user else None
+        account_name = account or "default"
+        return await self._get_third_party_credentials(user_id, "google", account_name)
 
     async def update_user(self, user_id: int, **data: Any) -> User | None:
         """Update a user's fields and return the updated record."""

--- a/src/the_assistant/integrations/google/client.py
+++ b/src/the_assistant/integrations/google/client.py
@@ -69,7 +69,7 @@ class GoogleClient:
             account: Optional account identifier when using multiple accounts
         """
         self.user_id = user_id
-        self.account = account
+        self.account = account or "default"
         self.settings = get_settings()
 
         self.credential_store = PostgresCredentialStore(

--- a/src/the_assistant/integrations/google/client.py
+++ b/src/the_assistant/integrations/google/client.py
@@ -570,7 +570,10 @@ class GoogleClient:
 
         credentials = await self.get_credentials()
         if not credentials:
-            raise GoogleAuthError("No valid credentials available")
+            raise GoogleAuthError(
+                f"No valid credentials available. User: {self.user_id}, Account: {self.account}"
+            )
+
         self._credentials = credentials
 
         try:

--- a/src/the_assistant/integrations/google/credential_store.py
+++ b/src/the_assistant/integrations/google/credential_store.py
@@ -45,7 +45,7 @@ class PostgresCredentialStore(CredentialStore):
         self.encryption_key = encryption_key
         self.fernet = Fernet(encryption_key.encode())
         self.user_service = user_service or get_user_service()
-        self.account = account
+        self.account = account or "default"
 
     async def get(self, user_id: int) -> Credentials | None:
         """Get credentials for a user."""

--- a/src/the_assistant/worker.py
+++ b/src/the_assistant/worker.py
@@ -33,6 +33,9 @@ from the_assistant.activities.obsidian_activities import (
 from the_assistant.activities.telegram_activities import (
     send_message,
 )
+from the_assistant.activities.user_activities import (
+    get_user_accounts,
+)
 from the_assistant.activities.weather_activities import get_weather_forecast
 from the_assistant.workflows.daily_briefing import DailyBriefing
 
@@ -73,6 +76,8 @@ async def run_worker() -> None:
                 get_upcoming_events_accounts,
                 # Obsidian activities
                 scan_vault_notes,
+                # User activities
+                get_user_accounts,
                 # Weather activities
                 get_weather_forecast,
                 # Messages activities

--- a/src/the_assistant/workflows/daily_briefing.py
+++ b/src/the_assistant/workflows/daily_briefing.py
@@ -25,6 +25,10 @@ with workflow.unsafe.imports_passed_through():
         SendMessageInput,
         send_message,
     )
+    from the_assistant.activities.user_activities import (
+        GetUserAccountsInput,
+        get_user_accounts,
+    )
     from the_assistant.activities.weather_activities import (
         GetWeatherForecastInput,
         get_weather_forecast,
@@ -35,7 +39,13 @@ with workflow.unsafe.imports_passed_through():
 class DailyBriefing:
     @workflow.run
     async def run(self, user_id: int) -> None:
-        accounts = ["personal", "work"]
+        # Get all available Google accounts for the user
+        accounts = await workflow.execute_activity(
+            get_user_accounts,
+            GetUserAccountsInput(user_id=user_id, provider="google"),
+            start_to_close_timeout=timedelta(seconds=5),
+            retry_policy=NO_RETRY,
+        )
 
         settings = await workflow.execute_activity(
             get_user_settings,

--- a/tests/integration/test_user_accounts_integration.py
+++ b/tests/integration/test_user_accounts_integration.py
@@ -1,0 +1,45 @@
+"""Integration test for user accounts functionality."""
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from the_assistant.db.models import Base
+from the_assistant.db.service import UserService
+
+
+@pytest.fixture
+async def session_maker(tmp_path):
+    """Create a test database session maker."""
+    db_path = tmp_path / "test.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield maker
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_daily_briefing_account_retrieval(session_maker):
+    """Test the complete flow of retrieving accounts for daily briefing."""
+    user_service = UserService(session_maker)
+
+    # Create a test user
+    user = await user_service.create_user(username="test_user")
+
+    # Initially, no accounts should exist
+    accounts = await user_service.get_user_accounts(user.id, "google")
+    assert accounts == []
+
+    # Add some Google accounts
+    await user_service.set_google_credentials(user.id, "cred1", "personal")
+    await user_service.set_google_credentials(user.id, "cred2", "work")
+    await user_service.set_google_credentials(user.id, "cred3", "default")
+
+    # Now we should get all accounts
+    accounts = await user_service.get_user_accounts(user.id, "google")
+    assert set(accounts) == {"personal", "work", "default"}
+
+    assert len(accounts) >= 1
+    assert "personal" in accounts
+    assert "work" in accounts

--- a/tests/unit/integrations/google/test_client.py
+++ b/tests/unit/integrations/google/test_client.py
@@ -107,11 +107,12 @@ class TestGoogleClient:
         assert client.settings == self.mock_settings
         self.mock_store_class.assert_called_once_with(
             encryption_key=self.mock_settings.db_encryption_key,
-            account=None,
+            account="default",
         )
         assert client.credential_store == self.mock_store_instance
         assert client.credentials_path == self.mock_settings.google_credentials_path
         assert client.scopes == self.mock_settings.google_oauth_scopes
+        assert client.account == "default"
 
     def test_init_with_account(self):
         """GoogleClient forwards account to credential store."""

--- a/tests/unit/test_user_activities.py
+++ b/tests/unit/test_user_activities.py
@@ -1,0 +1,48 @@
+"""Tests for user activities."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from the_assistant.activities.user_activities import (
+    GetUserAccountsInput,
+    get_user_accounts,
+)
+
+
+@pytest.mark.asyncio
+async def test_get_user_accounts():
+    """Test getting user accounts."""
+    # Mock the user service
+    mock_user_service = AsyncMock()
+    mock_user_service.get_user_accounts.return_value = ["personal", "work"]
+
+    with patch(
+        "the_assistant.activities.user_activities.get_user_service"
+    ) as mock_get_service:
+        mock_get_service.return_value = mock_user_service
+
+        input_data = GetUserAccountsInput(user_id=123, provider="google")
+        result = await get_user_accounts(input_data)
+
+        assert result == ["personal", "work"]
+        mock_user_service.get_user_accounts.assert_called_once_with(123, "google")
+
+
+@pytest.mark.asyncio
+async def test_get_user_accounts_empty():
+    """Test getting user accounts when none exist."""
+    # Mock the user service
+    mock_user_service = AsyncMock()
+    mock_user_service.get_user_accounts.return_value = []
+
+    with patch(
+        "the_assistant.activities.user_activities.get_user_service"
+    ) as mock_get_service:
+        mock_get_service.return_value = mock_user_service
+
+        input_data = GetUserAccountsInput(user_id=123, provider="google")
+        result = await get_user_accounts(input_data)
+
+        assert result == []
+        mock_user_service.get_user_accounts.assert_called_once_with(123, "google")

--- a/tests/unit/test_user_service.py
+++ b/tests/unit/test_user_service.py
@@ -81,7 +81,7 @@ async def test_google_credentials_multiple_accounts(user_service):
     )
     assert await user_service.get_google_credentials(user.id) == "cred-default"
 
-    # Ensure two third-party account records exist
+    # Ensure three third-party account records exist
     async with user_service._session_maker() as session:
         from the_assistant.db.models import ThirdPartyAccount
 
@@ -94,3 +94,29 @@ async def test_google_credentials_multiple_accounts(user_service):
             "work",
             "default",
         }
+
+
+@pytest.mark.asyncio
+async def test_get_user_accounts(user_service):
+    """Test getting all accounts for a user and provider."""
+    user = await user_service.create_user(username="accounts_test")
+
+    # Set up multiple Google accounts
+    await user_service.set_google_credentials(
+        user.id, "cred-personal", account="personal"
+    )
+    await user_service.set_google_credentials(user.id, "cred-work", account="work")
+    await user_service.set_google_credentials(user.id, "cred-default")
+
+    # Test getting Google accounts
+    google_accounts = await user_service.get_user_accounts(user.id, "google")
+    assert set(google_accounts) == {"personal", "work", "default"}
+
+    # Test with non-existent provider
+    other_accounts = await user_service.get_user_accounts(user.id, "other")
+    assert other_accounts == []
+
+    # Test with account that has no credentials (should be excluded)
+    await user_service._set_third_party_credentials(user.id, "google", None, "no_creds")
+    google_accounts_after = await user_service.get_user_accounts(user.id, "google")
+    assert set(google_accounts_after) == {"personal", "work", "default"}

--- a/tests/unit/test_user_service.py
+++ b/tests/unit/test_user_service.py
@@ -69,6 +69,7 @@ async def test_google_credentials_multiple_accounts(user_service):
         user.id, "cred-personal", account="personal"
     )
     await user_service.set_google_credentials(user.id, "cred-work", account="work")
+    await user_service.set_google_credentials(user.id, "cred-default")
 
     assert (
         await user_service.get_google_credentials(user.id, account="personal")
@@ -78,8 +79,7 @@ async def test_google_credentials_multiple_accounts(user_service):
         await user_service.get_google_credentials(user.id, account="work")
         == "cred-work"
     )
-    # Legacy column should remain empty
-    assert await user_service.get_google_credentials(user.id) is None
+    assert await user_service.get_google_credentials(user.id) == "cred-default"
 
     # Ensure two third-party account records exist
     async with user_service._session_maker() as session:
@@ -89,4 +89,8 @@ async def test_google_credentials_multiple_accounts(user_service):
             select(ThirdPartyAccount).where(ThirdPartyAccount.user_id == user.id)
         )
         accounts = result.scalars().all()
-        assert {a.account for a in accounts} == {"personal", "work"}
+        assert {a.account for a in accounts} == {
+            "personal",
+            "work",
+            "default",
+        }


### PR DESCRIPTION
## Summary
- store Google tokens in `third_party_accounts` for all cases
- default to the `"default"` account when none is specified
- update credential store and client accordingly
- adapt unit tests for new behaviour
- document third-party accounts in README

## Testing
- `make fix`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68861fb9004c8321829cad5bd4d05850