### PR TITLE
Clean up imports

### DIFF
--- a/src/the_assistant/integrations/obsidian/obsidian_client.py
+++ b/src/the_assistant/integrations/obsidian/obsidian_client.py
@@ -8,9 +8,12 @@ to provide a comprehensive API for note management, filtering, and task operatio
 
 import asyncio
 import logging
+import re
 from datetime import datetime
 from pathlib import Path
 from typing import Any
+
+import yaml
 
 from .filter_engine import FilterEngine
 from .markdown_parser import MarkdownParser
@@ -591,8 +594,6 @@ class ObsidianClient:
             return content
 
         # Build YAML frontmatter
-        import yaml
-
         yaml_content = yaml.dump(metadata, default_flow_style=False, allow_unicode=True)
 
         # Combine frontmatter and content
@@ -602,7 +603,6 @@ class ObsidianClient:
         self, content: str, task_text: str, completed: bool
     ) -> str:
         """Update task completion status in raw content while preserving formatting."""
-        import re
 
         # Pattern to match the specific task with flexible whitespace and formatting
         escaped_text = re.escape(task_text.strip())
@@ -656,7 +656,6 @@ class ObsidianClient:
 
 
 if __name__ == "__main__":
-    import asyncio
 
     async def main():
         client = ObsidianClient("~/dev/the_assistant/obsidian_vault", user_id=1)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,12 +5,14 @@ This module provides common fixtures, test markers, and configuration
 for all test categories (unit, integration, obsidian-specific).
 """
 
+import asyncio
 import os
 from datetime import date, datetime
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+import yaml
 
 from the_assistant.integrations.obsidian import MarkdownParser, MetadataExtractor
 
@@ -212,8 +214,6 @@ date: 2025-01-15
 @pytest.fixture
 def event_loop():
     """Create an event loop for async tests."""
-    import asyncio
-
     loop = asyncio.new_event_loop()
     yield loop
     loop.close()
@@ -254,8 +254,6 @@ class TestHelpers:
     def create_test_note(content: str, frontmatter: dict | None = None) -> str:
         """Create a test note with optional frontmatter."""
         if frontmatter:
-            import yaml
-
             frontmatter_str = yaml.dump(frontmatter, default_flow_style=False)
             return f"---\n{frontmatter_str}---\n\n{content}"
         return content

--- a/tests/integration/test_functionality_verification.py
+++ b/tests/integration/test_functionality_verification.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from the_assistant.integrations.obsidian.models import NoteNotFoundError
 from the_assistant.integrations.obsidian.vault_manager import VaultManager
 
 
@@ -140,7 +141,6 @@ class TestFunctionalityVerification:
 
     async def test_error_handling_unchanged(self, vault_manager):
         """Test that error handling behavior is unchanged."""
-        from the_assistant.integrations.obsidian.models import NoteNotFoundError
 
         # Test loading nonexistent note
         with pytest.raises(NoteNotFoundError):

--- a/tests/integration/test_task_management_integration.py
+++ b/tests/integration/test_task_management_integration.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import pytest
 
 from the_assistant.integrations.obsidian.models import (
+    NoteNotFoundError,
     TaskUpdateError,
 )
 from the_assistant.integrations.obsidian.obsidian_client import ObsidianClient
@@ -212,7 +213,6 @@ Some additional content here.
     @pytest.mark.asyncio
     async def test_error_handling_integration(self, client):
         """Test error handling with real vault operations."""
-        from the_assistant.integrations.obsidian.models import NoteNotFoundError
 
         # Test with non-existent note
         with pytest.raises(NoteNotFoundError):

--- a/tests/unit/integrations/google/test_oauth_router.py
+++ b/tests/unit/integrations/google/test_oauth_router.py
@@ -5,20 +5,18 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+import the_assistant.integrations.google.oauth_router as oauth_router
+
 
 def test_missing_jwt_secret_no_error():
     """Importing oauth_router without JWT_SECRET should not fail."""
     with patch.dict(os.environ, {}, clear=True):
-        import the_assistant.integrations.google.oauth_router as oauth_router
-
         importlib.reload(oauth_router)
 
 
 @pytest.mark.asyncio
 async def test_oauth_callback_sends_notification():
     """OAuth callback notifies the user via Telegram."""
-
-    import the_assistant.integrations.google.oauth_router as oauth_router
 
     user = SimpleNamespace(id=1, telegram_chat_id=456)
     service = AsyncMock()

--- a/tests/unit/integrations/llm/test_agent.py
+++ b/tests/unit/integrations/llm/test_agent.py
@@ -1,4 +1,5 @@
 import pytest
+from langchain.callbacks.base import BaseCallbackHandler
 from langchain_core.language_models.fake_chat_models import FakeChatModel
 from langchain_core.messages import AIMessage
 
@@ -38,8 +39,6 @@ async def test_llm_agent_runs(monkeypatch):
 @pytest.mark.asyncio
 async def test_llm_agent_langsmith(monkeypatch):
     tracer_called = False
-
-    from langchain.callbacks.base import BaseCallbackHandler
 
     class DummyTracer(BaseCallbackHandler):
         def __init__(self, project_name: str | None = None) -> None:

--- a/tests/unit/integrations/obsidian/test_obsidian_client.py
+++ b/tests/unit/integrations/obsidian/test_obsidian_client.py
@@ -5,7 +5,7 @@ These tests verify the functionality of the ObsidianClient class,
 which integrates all components for interacting with Obsidian vaults.
 """
 
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -509,8 +509,6 @@ class TestObsidianClient:
 
     async def test_filter_by_trip_tag_integration(self):
         """Test filtering notes by 'trip' tag using real vault data."""
-        from the_assistant.integrations.obsidian.models import NoteFilters
-
         # Use real ObsidianClient with actual vault path
         real_client = ObsidianClient("obsidian_vault", user_id=1)
 
@@ -566,8 +564,6 @@ class TestObsidianClient:
 
     async def test_single_tag_filter_edge_cases(self):
         """Test edge cases for single tag filtering."""
-        from the_assistant.integrations.obsidian.models import NoteFilters
-
         real_client = ObsidianClient("obsidian_vault", user_id=1)
 
         # Test with non-existent tag
@@ -595,10 +591,6 @@ class TestObsidianClient:
 
     async def test_trip_date_filtering_logic(self):
         """Test the specific filtering logic for trip notes with date ranges."""
-        from datetime import date, timedelta
-
-        from the_assistant.integrations.obsidian.models import NoteFilters
-
         real_client = ObsidianClient("obsidian_vault", user_id=1)
 
         # Get current month date range

--- a/tests/unit/integrations/telegram/test_telegram_client.py
+++ b/tests/unit/integrations/telegram/test_telegram_client.py
@@ -18,6 +18,7 @@ from the_assistant.integrations.telegram.telegram_client import (
     handle_memory_add_command,
     handle_memory_command,
     save_setting,
+    start_memory_delete,
     start_update_settings,
 )
 
@@ -573,9 +574,6 @@ class TestUpdateSettings:
             mock_context.args = ["1"]
             # Use start_memory_delete instead of handle_memory_delete_command
             # since the latter is now just a stub
-            from the_assistant.integrations.telegram.telegram_client import (
-                start_memory_delete,
-            )
 
             await start_memory_delete(mock_update, mock_context)
 

--- a/tests/unit/test_activities.py
+++ b/tests/unit/test_activities.py
@@ -22,11 +22,15 @@ from the_assistant.activities.messages_activities import (
     DailyBriefingInput,
     build_daily_briefing,
 )
-from the_assistant.activities.obsidian_activities import scan_vault_notes
+from the_assistant.activities.obsidian_activities import (
+    ScanVaultNotesInput,
+    scan_vault_notes,
+)
 from the_assistant.activities.weather_activities import (
     GetWeatherForecastInput,
     get_weather_forecast,
 )
+from the_assistant.models import NoteFilters
 from the_assistant.models.google import CalendarEvent, GmailMessage
 from the_assistant.models.weather import WeatherForecast
 
@@ -198,7 +202,6 @@ class TestObsidianActivities:
         self, mock_obsidian_client_class, mock_get_settings, mock_obsidian_client
     ):
         """Test successful vault scanning."""
-        from the_assistant.activities.obsidian_activities import ScanVaultNotesInput
 
         settings = AsyncMock()
         settings.obsidian_vault_path = "/path/to/vault"
@@ -221,8 +224,6 @@ class TestObsidianActivities:
         self, mock_obsidian_client_class, mock_get_settings, mock_obsidian_client
     ):
         """Test vault scanning with filters."""
-        from the_assistant.activities.obsidian_activities import ScanVaultNotesInput
-        from the_assistant.models import NoteFilters
 
         settings = AsyncMock()
         settings.obsidian_vault_path = "/path/to/vault"

--- a/tests/unit/test_llm_activity.py
+++ b/tests/unit/test_llm_activity.py
@@ -1,5 +1,6 @@
 import pytest
 from langchain_core.language_models.fake_chat_models import FakeChatModel
+from langchain_core.messages import AIMessage
 
 from the_assistant.activities.messages_activities import (
     BriefingSummaryInput,
@@ -9,8 +10,6 @@ from the_assistant.activities.messages_activities import (
 
 @pytest.mark.asyncio
 async def test_build_briefing_summary(monkeypatch):
-    from langchain_core.messages import AIMessage
-
     # Mock the create_react_agent function to avoid bind_tools issues
     class MockAgentExecutor:
         async def ainvoke(self, input_data, config=None):

--- a/tests/unit/test_user_service.py
+++ b/tests/unit/test_user_service.py
@@ -2,7 +2,7 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
-from the_assistant.db.models import Base
+from the_assistant.db.models import Base, ThirdPartyAccount
 from the_assistant.db.service import UserService
 from the_assistant.integrations.telegram.constants import SettingKey
 
@@ -83,8 +83,6 @@ async def test_google_credentials_multiple_accounts(user_service):
 
     # Ensure three third-party account records exist
     async with user_service._session_maker() as session:
-        from the_assistant.db.models import ThirdPartyAccount
-
         result = await session.execute(
             select(ThirdPartyAccount).where(ThirdPartyAccount.user_id == user.id)
         )

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -1,11 +1,13 @@
 """Tests for the Temporal worker."""
 
 import asyncio
+import logging
 import os
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
+import the_assistant.worker as worker_module
 from the_assistant.worker import main, run_worker
 
 # Suppress false positive warnings from mocking async operations
@@ -155,9 +157,6 @@ class TestWorker:
 
     def test_worker_activities_imported(self):
         """Test that all required activities are imported."""
-        # Import the worker module to check imports
-        import the_assistant.worker as worker_module
-
         # Check that activities are available
         assert hasattr(worker_module, "get_calendar_events")
         assert hasattr(worker_module, "get_upcoming_events")
@@ -169,8 +168,6 @@ class TestWorker:
 
     def test_worker_workflows_imported(self):
         """Test that all required workflows are imported."""
-        import the_assistant.worker as worker_module
-
         # Check that workflows are available
         assert hasattr(worker_module, "DailyBriefing")
 
@@ -241,6 +238,5 @@ class TestWorker:
 
         mock_logging_config.assert_called()
         call_args = mock_logging_config.call_args
-        import logging
 
         assert call_args[1]["level"] == logging.DEBUG


### PR DESCRIPTION
## Summary
- move imports to module level for tests and obsidian client
- keep workflow import lazy to avoid a circular import

## Testing
- `make ci`

------
https://chatgpt.com/codex/tasks/task_e_68862da69854832187b4b9b4efd78861