### PR TITLE
Implement scheduled task creation

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -3,8 +3,7 @@ import sys
 from logging.config import fileConfig
 from pathlib import Path
 
-from sqlalchemy import engine_from_config
-from sqlalchemy import pool
+from sqlalchemy import engine_from_config, pool
 
 from alembic import context
 

--- a/alembic/versions/7cc1a1bbfedb_initial_migration_with_all_tables.py
+++ b/alembic/versions/7cc1a1bbfedb_initial_migration_with_all_tables.py
@@ -1,21 +1,21 @@
 """Initial migration with all tables
 
 Revision ID: 7cc1a1bbfedb
-Revises: 
+Revises:
 Create Date: 2025-07-25 13:20:03.209305
 
 """
-from typing import Sequence, Union
+from collections.abc import Sequence
 
-from alembic import op
 import sqlalchemy as sa
 
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = '7cc1a1bbfedb'
-down_revision: Union[str, Sequence[str], None] = None
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | Sequence[str] | None = None
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:

--- a/alembic/versions/9b31f1c67e3a_add_tasks_table.py
+++ b/alembic/versions/9b31f1c67e3a_add_tasks_table.py
@@ -1,0 +1,33 @@
+"""Add tasks table
+
+Revision ID: 9b31f1c67e3a
+Revises: 7cc1a1bbfedb
+Create Date: 2025-07-28 00:00:00.000000
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = '9b31f1c67e3a'
+down_revision: str | Sequence[str] | None = '7cc1a1bbfedb'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'tasks',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('user_id', sa.Integer(), nullable=False),
+        sa.Column('raw_instruction', sa.Text(), nullable=False),
+        sa.Column('schedule', sa.String(), nullable=False),
+        sa.Column('instruction', sa.Text(), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id'], ondelete='CASCADE'),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('tasks')

--- a/src/the_assistant/db/__init__.py
+++ b/src/the_assistant/db/__init__.py
@@ -7,7 +7,7 @@ from .database import (
     get_session_maker,
     get_user_service,
 )
-from .models import Base, ThirdPartyAccount, User, UserSetting
+from .models import Base, ScheduledTask, ThirdPartyAccount, User, UserSetting
 from .service import UserService
 
 __all__ = [
@@ -16,6 +16,7 @@ __all__ = [
     "User",
     "UserSetting",
     "ThirdPartyAccount",
+    "ScheduledTask",
     "UserService",
     "get_database_manager",
     "get_session",

--- a/src/the_assistant/db/models.py
+++ b/src/the_assistant/db/models.py
@@ -50,6 +50,10 @@ class User(Base):
         back_populates="user",
         cascade="all, delete-orphan",
     )
+    tasks: Mapped[list["ScheduledTask"]] = relationship(
+        back_populates="user",
+        cascade="all, delete-orphan",
+    )
 
 
 class UserSetting(Base):
@@ -97,3 +101,22 @@ class ThirdPartyAccount(Base):
     )
 
     user: Mapped[User] = relationship(back_populates="third_party_accounts")
+
+
+class ScheduledTask(Base):
+    """User scheduled task."""
+
+    __tablename__ = "tasks"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    raw_instruction: Mapped[str] = mapped_column(Text, nullable=False)
+    schedule: Mapped[str] = mapped_column(String, nullable=False)
+    instruction: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+
+    user: Mapped[User] = relationship(back_populates="tasks")

--- a/src/the_assistant/db/service.py
+++ b/src/the_assistant/db/service.py
@@ -13,7 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from the_assistant.integrations.telegram.constants import SettingKey
 from the_assistant.user_settings import SETTING_SCHEMAS
 
-from .models import ThirdPartyAccount, User, UserSetting
+from .models import ScheduledTask, ThirdPartyAccount, User, UserSetting
 
 
 class UserService:
@@ -200,3 +200,30 @@ class UserService:
             result = await session.execute(stmt)
             accounts = result.scalars().all()
             return [account for account in accounts if account is not None]
+
+    async def create_task(
+        self, user_id: int, raw_instruction: str, schedule: str, instruction: str
+    ) -> ScheduledTask:
+        """Create a scheduled task for the user."""
+        from .models import ScheduledTask
+
+        async with self._session_maker() as session:
+            task = ScheduledTask(
+                user_id=user_id,
+                raw_instruction=raw_instruction,
+                schedule=schedule,
+                instruction=instruction,
+            )
+            session.add(task)
+            await session.commit()
+            await session.refresh(task)
+            return task
+
+    async def list_tasks(self, user_id: int) -> list[ScheduledTask]:
+        """Return all scheduled tasks for the user."""
+        from .models import ScheduledTask
+
+        async with self._session_maker() as session:
+            stmt = select(ScheduledTask).where(ScheduledTask.user_id == user_id)
+            result = await session.execute(stmt)
+            return result.scalars().all()

--- a/src/the_assistant/db/service.py
+++ b/src/the_assistant/db/service.py
@@ -205,7 +205,6 @@ class UserService:
         self, user_id: int, raw_instruction: str, schedule: str, instruction: str
     ) -> ScheduledTask:
         """Create a scheduled task for the user."""
-        from .models import ScheduledTask
 
         async with self._session_maker() as session:
             task = ScheduledTask(
@@ -221,8 +220,6 @@ class UserService:
 
     async def list_tasks(self, user_id: int) -> list[ScheduledTask]:
         """Return all scheduled tasks for the user."""
-        from .models import ScheduledTask
-
         async with self._session_maker() as session:
             stmt = select(ScheduledTask).where(ScheduledTask.user_id == user_id)
             result = await session.execute(stmt)

--- a/src/the_assistant/integrations/llm/__init__.py
+++ b/src/the_assistant/integrations/llm/__init__.py
@@ -1,5 +1,6 @@
 """LLM integration package."""
 
 from .agent import LLMAgent, Task
+from .task_parser import TaskParser
 
-__all__ = ["LLMAgent", "Task"]
+__all__ = ["LLMAgent", "Task", "TaskParser"]

--- a/src/the_assistant/integrations/llm/task_parser.py
+++ b/src/the_assistant/integrations/llm/task_parser.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import json
+
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_openai import ChatOpenAI
+
+DEFAULT_PROMPT = (
+    "You are a helpful assistant that extracts a recurring schedule and the action "
+    "to perform from a user instruction."
+    " Respond ONLY with a JSON object using keys 'schedule' and 'instruction'."
+)
+
+
+class TaskParser:
+    """Parse scheduling instructions using an LLM."""
+
+    def __init__(self, model: ChatOpenAI | None = None) -> None:
+        self.model = model or ChatOpenAI(model="gpt-4o-mini", temperature=0)  # type: ignore[unknown-argument]
+
+    async def parse(self, text: str) -> tuple[str, str]:
+        """Return schedule and instruction parsed from input."""
+        prompt = ChatPromptTemplate.from_messages(
+            [
+                ("system", DEFAULT_PROMPT),
+                ("human", "{text}"),
+            ]
+        )
+        chain = prompt | self.model
+        response = await chain.ainvoke({"text": text})
+        content = getattr(response, "content", str(response))
+        try:
+            data = json.loads(content)
+            schedule = str(data.get("schedule", ""))
+            instruction = str(data.get("instruction", ""))
+        except Exception:
+            schedule = ""
+            instruction = content
+        return schedule, instruction

--- a/src/the_assistant/integrations/llm/task_parser.py
+++ b/src/the_assistant/integrations/llm/task_parser.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from json import JSONDecodeError
 
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_openai import ChatOpenAI
@@ -33,7 +34,7 @@ class TaskParser:
             data = json.loads(content)
             schedule = str(data.get("schedule", ""))
             instruction = str(data.get("instruction", ""))
-        except Exception:
+        except JSONDecodeError:
             schedule = ""
             instruction = content
         return schedule, instruction

--- a/src/the_assistant/integrations/telegram/telegram_client.py
+++ b/src/the_assistant/integrations/telegram/telegram_client.py
@@ -53,6 +53,7 @@ COMMAND_REGISTRY: dict[str, str] = {
     "memory_add": "Remember a fact about you",
     "memory": "List your stored memories",
     "memory_delete": "Delete a memory by its id",
+    "add_task": "Create a new scheduled task",
 }
 
 
@@ -1020,6 +1021,38 @@ async def handle_memory_delete_command(
     pass
 
 
+async def handle_add_task_command(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> None:
+    """Create a scheduled task from user instruction."""
+    if not update.message or not update.effective_user:
+        return
+
+    raw_instruction = " ".join(getattr(context, "args", [])).strip()
+    if not raw_instruction:
+        await update.message.reply_text("Usage: /add_task <instruction>")
+        return
+
+    user_service = get_user_service()
+    user = await user_service.get_user_by_telegram_chat_id(update.effective_user.id)
+    if not user:
+        await update.message.reply_text(
+            "❌ You need to register first. Please use /start to register."
+        )
+        return
+
+    from the_assistant.integrations.llm import TaskParser
+
+    parser = TaskParser()
+    schedule, instruction = await parser.parse(raw_instruction)
+
+    await user_service.create_task(
+        user.id, raw_instruction, schedule=schedule, instruction=instruction
+    )
+
+    await update.message.reply_text("✅ Task added.")
+
+
 async def handle_status_command(
     update: Update,
     context: ContextTypes.DEFAULT_TYPE,
@@ -1103,6 +1136,7 @@ async def create_telegram_client() -> TelegramClient:
     await client.register_command_handler("memory_add", handle_memory_add_command)
     await client.register_command_handler("memory", handle_memory_command)
     await client.register_command_handler("memories", handle_memory_command)
+    await client.register_command_handler("add_task", handle_add_task_command)
     # Settings conversation handler
     settings_conv_handler = ConversationHandler(
         entry_points=[CommandHandler("update_settings", start_update_settings)],

--- a/src/the_assistant/integrations/telegram/telegram_client.py
+++ b/src/the_assistant/integrations/telegram/telegram_client.py
@@ -1045,6 +1045,11 @@ async def handle_add_task_command(
 
     parser = TaskParser()
     schedule, instruction = await parser.parse(raw_instruction)
+    if not schedule:
+        await update.message.reply_text(
+            "❌ Could not parse a schedule. Try something like 'every day at 6pm say hi'."
+        )
+        return
 
     await user_service.create_task(
         user.id, raw_instruction, schedule=schedule, instruction=instruction

--- a/tests/unit/test_task_parser.py
+++ b/tests/unit/test_task_parser.py
@@ -1,0 +1,22 @@
+import pytest
+from langchain_core.language_models.fake_chat_models import FakeChatModel
+from langchain_core.messages import AIMessage
+
+from the_assistant.integrations.llm.task_parser import TaskParser
+
+
+@pytest.mark.asyncio
+async def test_task_parser(monkeypatch):
+    class DummyModel(FakeChatModel):
+        async def ainvoke(self, input_data, config=None):
+            return AIMessage(
+                content='{"schedule": "daily 6pm", "instruction": "send word"}'
+            )
+
+    model = DummyModel()
+
+    parser = TaskParser(model=model)
+    schedule, instruction = await parser.parse("every day at 6pm send me a word")
+
+    assert schedule == "daily 6pm"
+    assert instruction == "send word"

--- a/tests/unit/test_user_service.py
+++ b/tests/unit/test_user_service.py
@@ -120,3 +120,20 @@ async def test_get_user_accounts(user_service):
     await user_service._set_third_party_credentials(user.id, "google", None, "no_creds")
     google_accounts_after = await user_service.get_user_accounts(user.id, "google")
     assert set(google_accounts_after) == {"personal", "work", "default"}
+
+
+@pytest.mark.asyncio
+async def test_task_creation_and_listing(user_service):
+    user = await user_service.create_user(username="taskuser")
+
+    task = await user_service.create_task(
+        user.id,
+        raw_instruction="every day at 6pm say hi",
+        schedule="daily 6pm",
+        instruction="say hi",
+    )
+    assert task.id is not None
+
+    tasks = await user_service.list_tasks(user.id)
+    assert len(tasks) == 1
+    assert tasks[0].raw_instruction == "every day at 6pm say hi"


### PR DESCRIPTION
## Summary
- support scheduled tasks via new `/add_task` bot command
- add `ScheduledTask` model and DB operations
- introduce `TaskParser` LLM utility
- include alembic migration for tasks table
- test task parser and DB operations

## Testing
- `ruff check --fix`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68863616fe0c8321990723b5fe8763e7