### PR TITLE
Add weather tool

### DIFF
--- a/src/the_assistant/models/__init__.py
+++ b/src/the_assistant/models/__init__.py
@@ -15,7 +15,7 @@ from .activity_models import (
 )
 from .google import CalendarEvent
 from .obsidian import NoteFilters
-from .weather import WeatherForecast
+from .weather import HourlyForecast, WeatherForecast
 
 __all__ = [
     # Input models
@@ -27,4 +27,5 @@ __all__ = [
     "NoteWithPendingTasks",
     "TripNote",
     "WeatherForecast",
+    "HourlyForecast",
 ]

--- a/src/the_assistant/models/weather.py
+++ b/src/the_assistant/models/weather.py
@@ -1,4 +1,4 @@
-from datetime import date
+from datetime import date, datetime
 
 from pydantic import Field, computed_field
 
@@ -27,6 +27,20 @@ WEATHER_CODE_MAP = {
 }
 
 
+class HourlyForecast(BaseAssistantModel):
+    """Hourly forecast entry."""
+
+    timestamp: datetime = Field(description="Forecast time in UTC")
+    weather_code: int = Field(description="Open-Meteo weather code")
+    temperature: float = Field(description="Temperature (°C)")
+
+    @computed_field
+    @property
+    def condition(self) -> str:
+        """Human readable weather condition."""
+        return WEATHER_CODE_MAP.get(self.weather_code, "Unknown")
+
+
 class WeatherForecast(BaseAssistantModel):
     """Simple weather forecast returned by the Open-Meteo API."""
 
@@ -35,6 +49,10 @@ class WeatherForecast(BaseAssistantModel):
     weather_code: int = Field(description="Open-Meteo weather code")
     temperature_max: float = Field(description="Maximum temperature (°C)")
     temperature_min: float = Field(description="Minimum temperature (°C)")
+    hourly: list[HourlyForecast] | None = Field(
+        default=None,
+        description="Hourly forecast entries for this date (UTC)",
+    )
 
     @computed_field
     @property

--- a/tests/unit/integrations/agent/test_agent_tools.py
+++ b/tests/unit/integrations/agent/test_agent_tools.py
@@ -1,9 +1,10 @@
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 
 import pytest
 
 from the_assistant.integrations.agent_tools import get_default_tools
 from the_assistant.models.google import CalendarEvent, GmailMessage
+from the_assistant.models.weather import HourlyForecast, WeatherForecast
 
 
 @pytest.mark.asyncio
@@ -112,3 +113,53 @@ async def test_get_email_tool(monkeypatch):
     tool_obj = next(t for t in tools if t.name == "get_email")
     result = await tool_obj.arun("m1")
     assert result["id"] == "m1"
+
+
+@pytest.mark.asyncio
+async def test_weather_tool(monkeypatch):
+    forecast = WeatherForecast(
+        location="Paris",
+        forecast_date=date(2024, 7, 10),
+        weather_code=1,
+        temperature_max=25,
+        temperature_min=15,
+    )
+
+    hourly = [
+        HourlyForecast(
+            timestamp=datetime(2024, 7, 10, 0, 0),
+            weather_code=1,
+            temperature=20.0,
+        )
+    ]
+
+    class DummyClient:
+        async def get_forecast(self, location: str, days: int = 16):
+            assert location == "Paris"
+            assert days == 16
+            return [forecast]
+
+        async def get_hourly_forecast(self, location: str, day: date):
+            assert location == "Paris"
+            assert day == date(2024, 7, 10)
+            return hourly
+
+    async def mock_get_mcp_tools():
+        return []
+
+    monkeypatch.setattr(
+        "the_assistant.integrations.agent_tools.WeatherClient",
+        lambda: DummyClient(),
+    )
+    monkeypatch.setattr(
+        "the_assistant.integrations.agent_tools.get_mcp_tools",
+        mock_get_mcp_tools,
+    )
+
+    tools = await get_default_tools(1)
+    tool_obj = next(t for t in tools if t.name == "weather")
+    result = await tool_obj.arun({"location": "Paris", "day": "2024-07-10"})
+
+    assert result["location"] == "Paris"
+    assert result["forecast_date"] == date(2024, 7, 10)
+    assert len(result["hourly"]) == 1


### PR DESCRIPTION
## Summary
- provide `weather` tool to fetch forecast for a location and date
- allow `date` or ISO string for the `day` argument
- add hourly support and look up date via a dictionary

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688649883e9c8321a2009dbd606503dc